### PR TITLE
RFC: eeprom24x: fix memory addressing for low-end devices

### DIFF
--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -10,7 +10,7 @@ fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
     let address = SlaveAddr::default();
     let mut eeprom = Eeprom24x::new_24x256(dev, address);
-    let memory_address = [0x12, 0x34];
+    let memory_address = 0x1234;
     let data = 0xAB;
 
     eeprom.write_byte(memory_address, data).unwrap();
@@ -20,8 +20,8 @@ fn main() {
     let read_data = eeprom.read_byte(memory_address).unwrap();
 
     println!(
-        "Read memory address: [{},{}], retrieved content: {}",
-        memory_address[0], memory_address[1], &read_data
+        "Read memory address: {}, retrieved content: {}",
+        memory_address, &read_data
     );
 
     let _dev = eeprom.destroy(); // Get the I2C device back

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -1,38 +1,37 @@
 extern crate eeprom24x;
-use eeprom24x::{page_size, Eeprom24x, Error, SlaveAddr};
+use eeprom24x::{addr_size, page_size, Eeprom24x, Error, SlaveAddr};
 extern crate embedded_hal_mock as hal;
 use hal::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 
 const DEV_ADDR: u8 = 0b101_0000;
 
 macro_rules! create {
-    ($create:ident, $PS:ident) => {
-        fn $create(transactions: &[I2cTrans]) -> Eeprom24x<I2cMock, page_size::$PS> {
+    ($create:ident, $AS:ident, $PS:ident) => {
+        fn $create(transactions: &[I2cTrans]) -> Eeprom24x<I2cMock, page_size::$PS, addr_size::$AS> {
             Eeprom24x::$create(I2cMock::new(&transactions), SlaveAddr::default())
         }
     };
 }
 
-fn destroy<T>(eeprom: Eeprom24x<I2cMock, T>) {
+fn destroy<T, V>(eeprom: Eeprom24x<I2cMock, T, V>) {
     eeprom.destroy().done();
 }
 
-create!(new_24x00,  No);
-create!(new_24x01,  B8);
-create!(new_24x02,  B8);
-create!(new_24x04,  B16);
-create!(new_24x08,  B16);
-create!(new_24x16,  B16);
-create!(new_24x32,  B32);
-create!(new_24x64,  B32);
-create!(new_24x128, B64);
-create!(new_24x256, B64);
-create!(new_24x512, B128);
-create!(new_24xm01, B256);
-create!(new_24xm02, B256);
+create!(new_24x00, One, No);
+create!(new_24x01, One, B8);
+create!(new_24x02, One, B8);
+create!(new_24x04, One, B16);
+create!(new_24x08, One, B16);
+create!(new_24x16, One, B16);
+create!(new_24x32, Two, B32);
+create!(new_24x64, Two, B32);
+create!(new_24x128, Two, B64);
+create!(new_24x256, Two, B64);
+create!(new_24x512, Two, B128);
+create!(new_24xm01, Two, B256);
+create!(new_24xm02, Two, B256);
 
-
-macro_rules! for_all_ics {
+macro_rules! for_all_ics{
     ($name:ident) => {
         mod $name {
             use super::*;
@@ -49,6 +48,63 @@ macro_rules! for_all_ics {
             $name!(for_24x512, new_24x512);
             $name!(for_24xm01, new_24xm01);
             $name!(for_24xm02, new_24xm02);
+        }
+    };
+}
+
+macro_rules! for_all_ics_with_1b_addr {
+    ($name:ident) => {
+        mod $name {
+            use super::*;
+            $name!(for_24x00,  new_24x00);
+            $name!(for_24x01,  new_24x01);
+            $name!(for_24x02,  new_24x02);
+            $name!(for_24x04,  new_24x04);
+            $name!(for_24x08,  new_24x08);
+            $name!(for_24x16,  new_24x16);
+        }
+    };
+}
+
+macro_rules! for_all_ics_with_2b_addr {
+    ($name:ident) => {
+        mod $name {
+            use super::*;
+            $name!(for_24x32,  new_24x32);
+            $name!(for_24x64,  new_24x64);
+            $name!(for_24x128, new_24x128);
+            $name!(for_24x256, new_24x256);
+            $name!(for_24x512, new_24x512);
+            $name!(for_24xm01, new_24xm01);
+            $name!(for_24xm02, new_24xm02);
+        }
+    };
+}
+
+macro_rules! for_all_ics_with_1b_addr_and_page_size {
+    ($name:ident) => {
+        mod $name {
+            use super::*;
+            $name!(for_24x01,  new_24x01,    8);
+            $name!(for_24x02,  new_24x02,    8);
+            $name!(for_24x04,  new_24x04,   16);
+            $name!(for_24x08,  new_24x08,   16);
+            $name!(for_24x16,  new_24x16,   16);
+        }
+    };
+}
+
+macro_rules! for_all_ics_with_2b_addr_and_page_size {
+    ($name:ident) => {
+        mod $name {
+            use super::*;
+            $name!(for_24x32,  new_24x32,   32);
+            $name!(for_24x64,  new_24x64,   32);
+            $name!(for_24x128, new_24x128,  64);
+            $name!(for_24x256, new_24x256,  64);
+            $name!(for_24x512, new_24x512, 128);
+            $name!(for_24xm01, new_24xm01, 256);
+            $name!(for_24xm02, new_24xm02, 256);
         }
     };
 }
@@ -84,34 +140,63 @@ macro_rules! construction_test {
 }
 for_all_ics!(construction_test);
 
-macro_rules! can_read_byte {
+macro_rules! can_read_byte_v1 {
     ($name:ident, $create:ident) => {
         #[test]
         fn $name() {
-            let trans = [I2cTrans::write_read(DEV_ADDR, vec![0x12, 0x34], vec![0xAB])];
+            let trans = [I2cTrans::write_read(DEV_ADDR, vec![0x34], vec![0xAB])];
             let mut eeprom = $create(&trans);
-            let data = eeprom.read_byte([0x12, 0x34]).unwrap();
+            let data = eeprom.read_byte(0x34).unwrap();
             assert_eq!(0xAB, data);
             destroy(eeprom);
         }
     };
 }
-for_all_ics!(can_read_byte);
+for_all_ics_with_1b_addr!(can_read_byte_v1);
 
-macro_rules! can_read_array {
+macro_rules! can_read_byte_v2 {
+    ($name:ident, $create:ident) => {
+        #[test]
+        fn $name() {
+            let trans = [I2cTrans::write_read(DEV_ADDR, vec![0x12, 0x34], vec![0xAB])];
+            let mut eeprom = $create(&trans);
+            let data = eeprom.read_byte(0x1234).unwrap();
+            assert_eq!(0xAB, data);
+            destroy(eeprom);
+        }
+    };
+}
+for_all_ics_with_2b_addr!(can_read_byte_v2);
+
+macro_rules! can_read_array_v1 {
+    ($name:ident, $create:ident) => {
+        #[test]
+        fn $name() {
+            let trans = [ I2cTrans::write_read(DEV_ADDR, vec![0x34], vec![0xAB, 0xCD, 0xEF]) ];
+            let mut eeprom = $create(&trans);
+            let mut data = [0; 3];
+            eeprom.read_data(0x34, &mut data).unwrap();
+            assert_eq!([0xAB, 0xCD, 0xEF], data);
+            destroy(eeprom);
+        }
+    };
+}
+for_all_ics_with_1b_addr!(can_read_array_v1);
+
+macro_rules! can_read_array_v2 {
     ($name:ident, $create:ident) => {
         #[test]
         fn $name() {
             let trans = [ I2cTrans::write_read(DEV_ADDR, vec![0x12, 0x34], vec![0xAB, 0xCD, 0xEF]) ];
             let mut eeprom = $create(&trans);
             let mut data = [0; 3];
-            eeprom.read_data([0x12, 0x34], &mut data).unwrap();
+            eeprom.read_data(0x1234, &mut data).unwrap();
             assert_eq!([0xAB, 0xCD, 0xEF], data);
             destroy(eeprom);
         }
     };
 }
-for_all_ics!(can_read_array);
+for_all_ics_with_2b_addr!(can_read_array_v2);
 
 macro_rules! can_read_current_address {
     ($name:ident, $create:ident) => {
@@ -127,43 +212,69 @@ macro_rules! can_read_current_address {
 }
 for_all_ics!(can_read_current_address);
 
-macro_rules! can_write_byte {
+macro_rules! can_write_byte_v1{
+    ($name:ident, $create:ident) => {
+        #[test]
+        fn $name() {
+            let trans = [I2cTrans::write(DEV_ADDR, vec![0x34, 0xAB])];
+            let mut eeprom = $create(&trans);
+            eeprom.write_byte(0x34, 0xAB).unwrap();
+            destroy(eeprom);
+        }
+    };
+}
+for_all_ics_with_1b_addr!(can_write_byte_v1);
+
+macro_rules! can_write_byte_v2{
     ($name:ident, $create:ident) => {
         #[test]
         fn $name() {
             let trans = [I2cTrans::write(DEV_ADDR, vec![0x12, 0x34, 0xAB])];
             let mut eeprom = $create(&trans);
-            eeprom.write_byte([0x12, 0x34], 0xAB).unwrap();
+            eeprom.write_byte(0x1234, 0xAB).unwrap();
             destroy(eeprom);
         }
     };
 }
-for_all_ics!(can_write_byte);
+for_all_ics_with_2b_addr!(can_write_byte_v2);
 
 macro_rules! write_empty_data_does_nothing {
     ($name:ident, $create:ident, $page_size:expr) => {
         #[test]
         fn $name() {
             let mut eeprom = $create(&[]);
-            eeprom.write_page([0x12, 0x34], &[]).unwrap();
+            eeprom.write_page(0x34, &[]).unwrap();
             destroy(eeprom);
         }
     };
 }
 for_all_ics_with_page_size!(write_empty_data_does_nothing);
 
-macro_rules! can_write_array {
+macro_rules! can_write_array_v1 {
+    ($name:ident, $create:ident, $page_size:expr) => {
+        #[test]
+        fn $name() {
+            let trans = [ I2cTrans::write(DEV_ADDR, vec![0x34, 0xAB, 0xCD, 0xEF]) ];
+            let mut eeprom = $create(&trans);
+            eeprom.write_page(0x34, &[0xAB, 0xCD, 0xEF]).unwrap();
+            destroy(eeprom);
+        }
+    };
+}
+for_all_ics_with_1b_addr_and_page_size!(can_write_array_v1);
+
+macro_rules! can_write_array_v2 {
     ($name:ident, $create:ident, $page_size:expr) => {
         #[test]
         fn $name() {
             let trans = [ I2cTrans::write(DEV_ADDR, vec![0x12, 0x34, 0xAB, 0xCD, 0xEF]) ];
             let mut eeprom = $create(&trans);
-            eeprom.write_page([0x12, 0x34], &[0xAB, 0xCD, 0xEF]).unwrap();
+            eeprom.write_page(0x1234, &[0xAB, 0xCD, 0xEF]).unwrap();
             destroy(eeprom);
         }
     };
 }
-for_all_ics_with_page_size!(can_write_array);
+for_all_ics_with_2b_addr_and_page_size!(can_write_array_v2);
 
 fn assert_too_much_data<T, E>(result: Result<T, Error<E>>) {
     match result {
@@ -172,13 +283,13 @@ fn assert_too_much_data<T, E>(result: Result<T, Error<E>>) {
     }
 }
 #[test]
-fn check_assert_matches() {
+fn check_data_assert_matches() {
     assert_too_much_data::<(), ()>(Err(Error::TooMuchData));
 }
 
 #[test]
 #[should_panic]
-fn check_assert_fails() {
+fn check_data_assert_fails() {
     assert_too_much_data::<(), ()>(Ok(()));
 }
 
@@ -187,14 +298,29 @@ macro_rules! cannot_write_too_big_page {
         #[test]
         fn $name() {
             let mut eeprom = $create(&[]);
-            assert_too_much_data(eeprom.write_page([0x12, 0x34], &[0xAB; 1 + $size]));
+            assert_too_much_data(eeprom.write_page(0x34, &[0xAB; 1 + $size]));
             destroy(eeprom);
         }
     };
 }
 for_all_ics_with_page_size!(cannot_write_too_big_page);
 
-macro_rules! can_write_whole_page {
+macro_rules! can_write_whole_page_v1 {
+    ($name:ident, $create:ident, $size:expr) => {
+        #[test]
+        fn $name() {
+            let mut data = vec![0x34];
+            data.extend_from_slice(&[0xAB; $size]);
+            let trans = [I2cTrans::write(DEV_ADDR, data)];
+            let mut eeprom = $create(&trans);
+            eeprom.write_page(0x34, &[0xAB; $size]).unwrap();
+            destroy(eeprom);
+        }
+    };
+}
+for_all_ics_with_1b_addr_and_page_size!(can_write_whole_page_v1);
+
+macro_rules! can_write_whole_page_v2 {
     ($name:ident, $create:ident, $size:expr) => {
         #[test]
         fn $name() {
@@ -202,9 +328,50 @@ macro_rules! can_write_whole_page {
             data.extend_from_slice(&[0xAB; $size]);
             let trans = [I2cTrans::write(DEV_ADDR, data)];
             let mut eeprom = $create(&trans);
-            eeprom.write_page([0x12, 0x34], &[0xAB; $size]).unwrap();
+            eeprom.write_page(0x1234, &[0xAB; $size]).unwrap();
             destroy(eeprom);
         }
     };
 }
-for_all_ics_with_page_size!(can_write_whole_page);
+for_all_ics_with_2b_addr_and_page_size!(can_write_whole_page_v2);
+
+fn assert_invalid_address<T, E>(result: Result<T, Error<E>>) {
+    match result {
+        Err(Error::InvalidAddr) => (),
+        _ => panic!("Error::InvalidAddr not returned."),
+    }
+}
+#[test]
+fn check_addr_assert_matches() {
+    assert_invalid_address::<(), ()>(Err(Error::InvalidAddr));
+}
+
+#[test]
+#[should_panic]
+fn check_addr_assert_fails() {
+    assert_invalid_address::<(), ()>(Ok(()));
+}
+
+macro_rules! cannot_write_invalid_addr_v1 {
+    ($name:ident, $create:ident) => {
+        #[test]
+        fn $name() {
+            let mut eeprom = $create(&[]);
+            assert_invalid_address(eeprom.write_byte(0xFFF, 0xAB));
+            destroy(eeprom);
+        }
+    };
+}
+for_all_ics_with_1b_addr!(cannot_write_invalid_addr_v1);
+
+macro_rules! cannot_write_invalid_addr_v2 {
+    ($name:ident, $create:ident) => {
+        #[test]
+        fn $name() {
+            let mut eeprom = $create(&[]);
+            assert_invalid_address(eeprom.write_byte(0xFFFFF, 0xAB));
+            destroy(eeprom);
+        }
+    };
+}
+for_all_ics_with_2b_addr!(cannot_write_invalid_addr_v2);


### PR DESCRIPTION
Hi @eldruin 

Here is an RFC PR to fix issue #6 . The idea is straightforward - to extend current implementation in the following two ways:
- add one more PhantomData marker to distinguish 1-byte and 2-byte devices
- add _devmask_ property to specify number of memory address most significant bits that should be appended to device address.

Test suite has also been modified as a part of this PR:
- split tests for 1-byte and 2-byte devices
- add tests for invalid memory addresses

All tests pass now. Besides, I verified the change using actual device at hand: AT24C04.

Regards,
Sergey

----

From commit message:

Current implementation assumes that memory address consists of two bytes.
In other words, three consecutive address bytes should be included into
each r/w operation (except read from current address):
- devaddr (i2c address)
- most significant byte of 2-byte memory address
- least significant byte of 2-byte memory address

However, according to datasheets, the things are a bit more complicated:
1. Low-end devices need only 1-byte memory address:
   AT24C00, AT24C02, AT24C04, AT24C08, AT24C016

2. Some devices need to keep most significant bits of memory addresses
   in least significant bits i2c device address:
   - 1-byte addr devices
     -- AT24C04: 1 bit of memory address
     -- AT24C08: 2  bits of memory address
     -- AT24C16: 3  bits of memory address
   - 2-byte addr devices
     -- AT24CM01: 1 bit of memory address
     -- AT24CM02: 2 bits of memory address

This commit implements the following changes:

- introduce one more PhantomData marker to distinguish between
  1-byte and 2-byte memory address operations

- implement separate read/write operations for 1-byte and 2-byte
  devices using new PhantomData to distinguish between them

- add new device characteristics: devmask - number of memory
  address most significant bits that should be appended to
  i2c address

- modify interface test suite: different test sets are needed
  for 1-byte and 2-byte devices

- add more tests to interface test suite: invalid address tests

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>