### PR TITLE
Add ST's m24c01/02 devices + Impl embedded_storage traits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.31.0]
+        rust: [stable, 1.50.0]
         TARGET:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.50.0]
+        rust: [stable, 1.51.0]
         TARGET:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-...
+- Add support for STM M24C01 and M24C02.
+- Implement `embedded_storage::ReadStorage` and `embedded_storage::Storage` traits.
+- ...
 
 ## [0.4.0] - 2021-09-04
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ include = [
     "/LICENSE-APACHE",
 ]
 edition = "2018"
+resolver = "2"
 
 [dependencies]
 embedded-hal = "0.2"
@@ -28,7 +29,7 @@ nb = "1.0.0"
 [dev-dependencies]
 linux-embedded-hal = "0.3"
 embedded-hal-mock = "0.8"
-void = "1.0.2"
+void = { version = "1.0.2", default-features = false }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ nb = "1.0.0"
 [dev-dependencies]
 linux-embedded-hal = "0.3"
 embedded-hal-mock = "0.8"
+void = "1.0.2"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ edition = "2018"
 
 [dependencies]
 embedded-hal = "0.2"
+embedded-storage = "0.2.0"
+nb = "1.0.0"
 
 [dev-dependencies]
 linux-embedded-hal = "0.3"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ applications where low power and low voltage operation are essential.
 |-------:|------------:|------------:|----------:|:-----------|
 |  24x00 |    128 bits |          16 |       N/A | [24C00]    |
 |  24x01 |      1 Kbit |         128 |   8 bytes | [AT24C01]  |
-|  24x02 |      2 Kbit |         256 |   8 bytes | [AT24C02]  |
+| M24x01 |      1 Kbit |         128 |  16 bytes | [M24C01]   |
+|  24x02 |      2 Kbit |         256 |   8 bytes | [M24C02]   |
+| M24x02 |      2 Kbit |         256 |  16 bytes | [AT24C02]  |
 |  24x04 |      4 Kbit |         512 |  16 bytes | [AT24C04]  |
 |  24x08 |      8 Kbit |       1,024 |  16 bytes | [AT24C08]  |
 |  24x16 |     16 Kbit |       2,048 |  16 bytes | [AT24C16]  |
@@ -45,19 +47,21 @@ applications where low power and low voltage operation are essential.
 | 24xM01 |      1 Mbit |     131,072 | 256 bytes | [AT24CM01] |
 | 24xM02 |      2 Mbit |     262,144 | 256 bytes | [AT24CM02] |
 
-[24C00]: http://ww1.microchip.com/downloads/en/DeviceDoc/24AA00-24LC00-24C00-Data-Sheet-20001178J.pdf
-[AT24C01]: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8871F-SEEPROM-AT24C01D-02D-Datasheet.pdf
-[AT24C02]: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8871F-SEEPROM-AT24C01D-02D-Datasheet.pdf
-[AT24C04]: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8896E-SEEPROM-AT24C04D-Datasheet.pdf
-[AT24C08]: http://ww1.microchip.com/downloads/en/DeviceDoc/AT24C08D-I2C-Compatible-2-Wire-Serial-EEPROM-20006022A.pdf
-[AT24C16]: http://ww1.microchip.com/downloads/en/DeviceDoc/20005858A.pdf
-[AT24C32]: http://ww1.microchip.com/downloads/en/devicedoc/doc0336.pdf
-[AT24C64]: http://ww1.microchip.com/downloads/en/devicedoc/doc0336.pdf
-[AT24C128]: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8734-SEEPROM-AT24C128C-Datasheet.pdf
-[AT24C256]: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8568-SEEPROM-AT24C256C-Datasheet.pdf
-[AT24C512]: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8720-SEEPROM-AT24C512C-Datasheet.pdf
-[AT24CM01]: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8812-SEEPROM-AT24CM01-Datasheet.pdf
-[AT24CM02]: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8828-SEEPROM-AT24CM02-Datasheet.pdf
+[24C00]: https://ww1.microchip.com/downloads/en/DeviceDoc/24AA00-24LC00-24C00-Data-Sheet-20001178J.pdf
+[AT24C01]: https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8871F-SEEPROM-AT24C01D-02D-Datasheet.pdf
+[M24C01]: https://www.st.com/resource/en/datasheet/m24c01-r.pdf
+[AT24C02]: https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8871F-SEEPROM-AT24C01D-02D-Datasheet.pdf
+[M24C02]: https://www.st.com/resource/en/datasheet/m24c02-r.pdf
+[AT24C04]: https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8896E-SEEPROM-AT24C04D-Datasheet.pdf
+[AT24C08]: https://ww1.microchip.com/downloads/en/DeviceDoc/AT24C08D-I2C-Compatible-2-Wire-Serial-EEPROM-20006022A.pdf
+[AT24C16]: https://ww1.microchip.com/downloads/en/DeviceDoc/20005858A.pdf
+[AT24C32]: https://ww1.microchip.com/downloads/en/devicedoc/doc0336.pdf
+[AT24C64]: https://ww1.microchip.com/downloads/en/devicedoc/doc0336.pdf
+[AT24C128]: https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8734-SEEPROM-AT24C128C-Datasheet.pdf
+[AT24C256]: https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8568-SEEPROM-AT24C256C-Datasheet.pdf
+[AT24C512]: https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8720-SEEPROM-AT24C512C-Datasheet.pdf
+[AT24CM01]: https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8812-SEEPROM-AT24CM01-Datasheet.pdf
+[AT24CM02]: https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8828-SEEPROM-AT24CM02-Datasheet.pdf
 
 ## Usage
 

--- a/src/eeprom24x.rs
+++ b/src/eeprom24x.rs
@@ -246,7 +246,9 @@ impl_for_page_size!(
     16,
     ["24x04", "AT24C04", 9, new_24x04],
     ["24x08", "AT24C08", 10, new_24x08],
-    ["24x16", "AT24C16", 11, new_24x16]
+    ["24x16", "AT24C16", 11, new_24x16],
+    ["M24C01", "M24C01", 7, new_m24x01],
+    ["M24C02", "M24C02", 8, new_m24x02]
 );
 impl_for_page_size!(
     TwoBytes,

--- a/src/eeprom24x.rs
+++ b/src/eeprom24x.rs
@@ -202,7 +202,7 @@ macro_rules! impl_for_page_size {
                 }
 
                 // check this before to ensure that data.len() fits into u32
-                // ($page_size always fits as its maximum value es 256).
+                // ($page_size always fits as its maximum value is 256).
                 if data.len() > $page_size {
                     // This would actually be supported by the EEPROM but
                     // the data in the page would be overwritten
@@ -228,7 +228,28 @@ macro_rules! impl_for_page_size {
             }
         }
 
+        impl<I2C, E, AS> PageWrite<E> for Eeprom24x<I2C, page_size::$PS, AS>
+        where
+            I2C: Write<Error = E>,
+            AS: MultiSizeAddr,
+        {
+            fn page_write(&mut self, address: u32, data: &[u8]) -> Result<(), Error<E>> {
+                self.write_page(address, data)
+            }
+
+            fn page_size(&self) -> usize {
+                $page_size
+            }
+        }
+
     };
+}
+
+/// Helper trait which gives the Storage implementation access to the `write_page` method and
+/// information about the page size
+pub trait PageWrite<E> {
+    fn page_write(&mut self, address: u32, data: &[u8]) -> Result<(), Error<E>>;
+    fn page_size(&self) -> usize;
 }
 
 impl_for_page_size!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,16 @@ pub struct Eeprom24x<I2C, PS, AS> {
     _as: PhantomData<AS>,
 }
 
+/// EEPROM24X extension which supports the `embedded-storage` traits but requires an
+/// `embedded_hal::timer::CountDown` to handle the timeouts when writing over page boundaries
+#[derive(Debug)]
+pub struct Storage<I2C, PS, AS, CD> {
+    /// Eeprom driver over which we implement the Storage traits
+    pub eeprom: Eeprom24x<I2C, PS, AS>,
+    /// CountDown timer
+    count_down: CD,
+}
+
 mod private {
     use crate::addr_size;
 
@@ -217,3 +227,4 @@ mod private {
 
 mod eeprom24x;
 mod slave_addr;
+mod storage;

--- a/src/slave_addr.rs
+++ b/src/slave_addr.rs
@@ -18,11 +18,22 @@ impl SlaveAddr {
         }
     }
 
-    /// Get the device address possibly including some bits from the memory address
-    pub(crate) fn devaddr(self, memory_address: u32, address_bits: u8, shift: u8) -> u8 {
-        let devmask = ((1 << address_bits) - 1) >> shift;
-        let hi = (memory_address & !(1 << address_bits)) >> shift;
-        (self.addr() & !(devmask as u8)) | hi as u8
+    /// Get the device address possibly including some bits from the memory address, e.g. for
+    /// AT24C16 the 8 bit device address is: 1 0 1 0 A10 A9 A8 R/W , i.e. the highest 3 bits of
+    /// the memory address are moved into the device address.
+    ///
+    /// num_address_bits is the total number of address bits, shift is the number of address bits
+    /// which are transmitted separately. Theoretically, max(0, num_address_bits-shift) is the
+    /// number of address bits that are moved into the device address, but this overflows in many
+    /// cases and requires special handling for num_address_bits < shift.
+    pub(crate) fn devaddr(self, memory_address: u32, num_address_bits: u8, shift: u8) -> u8 {
+        // the part in parentheses creates num_address_bits ones; after right-shifting, 0..3 ones
+        // remain; the calculations have to be done in u32 to prevent overflow
+        let memmask: u32 = ((1 << num_address_bits) - 1) >> shift;
+        // the inverse is the part of the device address that we keep
+        let devmask = !memmask as u8;
+        let hi_addr_bits = memory_address >> shift;
+        (self.addr() & devmask) | hi_addr_bits as u8
     }
 }
 
@@ -54,5 +65,31 @@ mod tests {
             SlaveAddr::Alternative(true, false, false).addr()
         );
         assert_eq!(0b101_0111, SlaveAddr::Alternative(true, true, true).addr());
+    }
+
+    #[test]
+    fn assemble_devaddr() {
+        assert_eq!(0b101_0001, SlaveAddr::Default.devaddr(0b1_1111_1111, 9, 8));
+        assert_eq!(0b101_0000, SlaveAddr::Default.devaddr(0b0_1111_1111, 9, 8));
+        assert_eq!(
+            0b101_0011,
+            SlaveAddr::Default.devaddr(0b11_1111_1111, 10, 8)
+        );
+        assert_eq!(
+            0b101_0010,
+            SlaveAddr::Default.devaddr(0b10_1111_1111, 10, 8)
+        );
+        assert_eq!(
+            0b101_0111,
+            SlaveAddr::Default.devaddr(0b111_1111_1111, 11, 8)
+        );
+        assert_eq!(
+            0b101_0101,
+            SlaveAddr::Default.devaddr(0b101_1111_1111, 11, 8)
+        );
+        assert_eq!(
+            0b101_0101,
+            SlaveAddr::Default.devaddr(0b101_1111_1111_1111_1111, 19, 16)
+        );
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -60,10 +60,10 @@ where
         if offset as usize + bytes.len() > self.capacity() {
             return Err(Error::TooMuchData);
         }
-        while bytes.len() > 0 {
-            let this_page_index = offset as usize % self.eeprom.page_size();
-            let next_page_start = (this_page_index + 1) * self.eeprom.page_size();
-            let this_page_remaining = next_page_start - offset as usize;
+        while !bytes.is_empty() {
+            let page_size = self.eeprom.page_size();
+            let this_page_offset = offset as usize % page_size;
+            let this_page_remaining = page_size - this_page_offset;
             let chunk_size = min(bytes.len(), this_page_remaining);
             self.eeprom.page_write(offset, &bytes[..chunk_size])?;
             offset += chunk_size as u32;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,13 +13,7 @@ use embedded_storage::ReadStorage;
 impl<I2C, PS, AS, CD> Storage<I2C, PS, AS, CD> {}
 
 /// Common methods
-impl<I2C, E, PS, AS, CD> Storage<I2C, PS, AS, CD>
-where
-    I2C: Write<Error = E> + WriteRead<Error = E>,
-    AS: MultiSizeAddr,
-    Eeprom24x<I2C, PS, AS>: PageWrite<E>,
-    CD: CountDown<Time = Duration>,
-{
+impl<I2C, PS, AS, CD> Storage<I2C, PS, AS, CD> {
     /// Create a new Storage instance wrapping the given Eeprom
     pub fn new(eeprom: Eeprom24x<I2C, PS, AS>, count_down: CD) -> Self {
         Storage { eeprom, count_down }
@@ -35,7 +29,6 @@ impl<I2C, E, PS, AS, CD> embedded_storage::ReadStorage for Storage<I2C, PS, AS, 
 where
     I2C: Write<Error = E> + WriteRead<Error = E>,
     AS: MultiSizeAddr,
-    Eeprom24x<I2C, PS, AS>: PageWrite<E>,
     CD: CountDown<Time = Duration>,
 {
     type Error = Error<E>;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,12 +13,25 @@ use embedded_storage::ReadStorage;
 impl<I2C, PS, AS, CD> Storage<I2C, PS, AS, CD> {}
 
 /// Common methods
-impl<I2C, PS, AS, CD> Storage<I2C, PS, AS, CD> {
+impl<I2C, PS, AS, CD> Storage<I2C, PS, AS, CD>
+where
+    CD: CountDown<Time = Duration>,
+{
     /// Create a new Storage instance wrapping the given Eeprom
-    pub fn new(eeprom: Eeprom24x<I2C, PS, AS>, count_down: CD) -> Self {
+    pub fn new(eeprom: Eeprom24x<I2C, PS, AS>, mut count_down: CD) -> Self {
+        // When writing to the eeprom, we start a countdown of 5 ms after each page and wait for
+        // the timer before writing to the next page. Therefore, we always need a valid countdown
+        // so we start it here without any delay.
+        // Furthermore, we also have to wait for the countdown before reading the eeprom again.
+        // Basically, we have to wait before any I2C access and ensure that the countdown is
+        // running again afterwards.
+        count_down.start(Duration::from_millis(0));
         Storage { eeprom, count_down }
     }
+}
 
+/// Common methods
+impl<I2C, PS, AS, CD> Storage<I2C, PS, AS, CD> {
     /// Destroy driver instance, return I²C bus and timer instance.
     pub fn destroy(self) -> (I2C, CD) {
         (self.eeprom.destroy(), self.count_down)
@@ -34,6 +47,8 @@ where
     type Error = Error<E>;
 
     fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        let _ = nb::block!(self.count_down.wait()); // CountDown::wait() never fails
+        self.count_down.start(Duration::from_millis(0));
         self.eeprom.read_data(offset, bytes)
     }
 
@@ -55,6 +70,7 @@ where
         }
         let page_size = self.eeprom.page_size();
         while !bytes.is_empty() {
+            let _ = nb::block!(self.count_down.wait()); // CountDown::wait() never fails
             let this_page_offset = offset as usize % page_size;
             let this_page_remaining = page_size - this_page_offset;
             let chunk_size = min(bytes.len(), this_page_remaining);
@@ -64,10 +80,10 @@ where
             // TODO At least ST's eeproms allow polling, i.e. trying the next i2c access which will
             // just be NACKed as long as the device is still busy. This could potentially speed up
             // the write process.
+            // TODO Currently outdated comment:
             // A (theoretically needless) delay after the last page write ensures that the user can
             // call Storage::write() again immediately.
             self.count_down.start(Duration::from_millis(5));
-            let _ = nb::block!(self.count_down.wait()); // CountDown::wait() never fails
         }
         Ok(())
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -53,8 +53,8 @@ where
         if offset as usize + bytes.len() > self.capacity() {
             return Err(Error::TooMuchData);
         }
+        let page_size = self.eeprom.page_size();
         while !bytes.is_empty() {
-            let page_size = self.eeprom.page_size();
             let this_page_offset = offset as usize % page_size;
             let this_page_remaining = page_size - this_page_offset;
             let chunk_size = min(bytes.len(), this_page_remaining);
@@ -67,7 +67,7 @@ where
             // A (theoretically needless) delay after the last page write ensures that the user can
             // call Storage::write() again immediately.
             self.count_down.start(Duration::from_millis(5));
-            nb::block!(self.count_down.wait()).unwrap(); // CountDown::wait() never fails
+            let _ = nb::block!(self.count_down.wait()); // CountDown::wait() never fails
         }
         Ok(())
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,81 @@
+use crate::{
+    eeprom24x::{MultiSizeAddr, PageWrite},
+    Eeprom24x, Error, Storage,
+};
+use core::{cmp::min, time::Duration};
+use embedded_hal::{
+    blocking::i2c::{Write, WriteRead},
+    timer::CountDown,
+};
+use embedded_storage::ReadStorage;
+
+/// Common methods
+impl<I2C, PS, AS, CD> Storage<I2C, PS, AS, CD> {}
+
+/// Common methods
+impl<I2C, E, PS, AS, CD> Storage<I2C, PS, AS, CD>
+where
+    I2C: Write<Error = E> + WriteRead<Error = E>,
+    AS: MultiSizeAddr,
+    Eeprom24x<I2C, PS, AS>: PageWrite<E>,
+    CD: CountDown<Time = Duration>,
+{
+    /// Create a new Storage instance wrapping the given Eeprom
+    pub fn new(eeprom: Eeprom24x<I2C, PS, AS>, count_down: CD) -> Self {
+        Storage { eeprom, count_down }
+    }
+
+    /// Destroy driver instance, return I²C bus and timer instance.
+    pub fn destroy(self) -> (I2C, CD) {
+        (self.eeprom.destroy(), self.count_down)
+    }
+}
+
+impl<I2C, E, PS, AS, CD> embedded_storage::ReadStorage for Storage<I2C, PS, AS, CD>
+where
+    I2C: Write<Error = E> + WriteRead<Error = E>,
+    AS: MultiSizeAddr,
+    Eeprom24x<I2C, PS, AS>: PageWrite<E>,
+    CD: CountDown<Time = Duration>,
+{
+    type Error = Error<E>;
+
+    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        self.eeprom.read_data(offset, bytes)
+    }
+
+    fn capacity(&self) -> usize {
+        1 << self.eeprom.address_bits
+    }
+}
+
+impl<I2C, E, PS, AS, CD> embedded_storage::Storage for Storage<I2C, PS, AS, CD>
+where
+    I2C: Write<Error = E> + WriteRead<Error = E>,
+    AS: MultiSizeAddr,
+    Eeprom24x<I2C, PS, AS>: PageWrite<E>,
+    CD: CountDown<Time = Duration>,
+{
+    fn write(&mut self, mut offset: u32, mut bytes: &[u8]) -> Result<(), Self::Error> {
+        if offset as usize + bytes.len() > self.capacity() {
+            return Err(Error::TooMuchData);
+        }
+        while bytes.len() > 0 {
+            let this_page_index = offset as usize % self.eeprom.page_size();
+            let next_page_start = (this_page_index + 1) * self.eeprom.page_size();
+            let this_page_remaining = next_page_start - offset as usize;
+            let chunk_size = min(bytes.len(), this_page_remaining);
+            self.eeprom.page_write(offset, &bytes[..chunk_size])?;
+            offset += chunk_size as u32;
+            bytes = &bytes[chunk_size..];
+            // TODO At least ST's eeproms allow polling, i.e. trying the next i2c access which will
+            // just be NACKed as long as the device is still busy. This could potentially speed up
+            // the write process.
+            // A (theoretically needless) delay after the last page write ensures that the user can
+            // call Storage::write() again immediately.
+            self.count_down.start(Duration::from_millis(5));
+            nb::block!(self.count_down.wait()).unwrap(); // CountDown::wait() never fails
+        }
+        Ok(())
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -20,7 +20,9 @@ pub fn destroy<T, V>(eeprom: Eeprom24x<I2cMock, T, V>) {
 
 create!(new_24x00, OneByte, No);
 create!(new_24x01, OneByte, B8);
+create!(new_m24x01, OneByte, B16);
 create!(new_24x02, OneByte, B8);
+create!(new_m24x02, OneByte, B16);
 create!(new_24x04, OneByte, B16);
 create!(new_24x08, OneByte, B16);
 create!(new_24x16, OneByte, B16);
@@ -39,7 +41,9 @@ macro_rules! for_all_ics {
             use super::*;
             $name!(for_24x00, new_24x00);
             $name!(for_24x01, new_24x01);
+            $name!(for_m24x01, new_m24x01);
             $name!(for_24x02, new_24x02);
+            $name!(for_m24x02, new_m24x02);
             $name!(for_24x04, new_24x04);
             $name!(for_24x08, new_24x08);
             $name!(for_24x16, new_24x16);
@@ -61,7 +65,9 @@ macro_rules! for_all_ics_with_1b_addr {
             use super::*;
             $name!(for_24x00, new_24x00);
             $name!(for_24x01, new_24x01);
+            $name!(for_m24x01, new_m24x01);
             $name!(for_24x02, new_24x02);
+            $name!(for_m24x02, new_m24x02);
             $name!(for_24x04, new_24x04);
             $name!(for_24x08, new_24x08);
             $name!(for_24x16, new_24x16);
@@ -91,7 +97,9 @@ macro_rules! for_all_ics_with_1b_addr_and_page_size {
         mod $name {
             use super::*;
             $name!(for_24x01, new_24x01, 8);
+            $name!(for_m24x01, new_m24x01, 16);
             $name!(for_24x02, new_24x02, 8);
+            $name!(for_m24x02, new_m24x02, 16);
             $name!(for_24x04, new_24x04, 16);
             $name!(for_24x08, new_24x08, 16);
             $name!(for_24x16, new_24x16, 16);
@@ -121,7 +129,9 @@ macro_rules! for_all_ics_with_page_size {
         mod $name {
             use super::*;
             $name!(for_24x01, new_24x01, 8);
+            $name!(for_m24x01, new_m24x01, 16);
             $name!(for_24x02, new_24x02, 8);
+            $name!(for_m24x02, new_m24x02, 16);
             $name!(for_24x04, new_24x04, 16);
             $name!(for_24x08, new_24x08, 16);
             $name!(for_24x16, new_24x16, 16);
@@ -132,6 +142,53 @@ macro_rules! for_all_ics_with_page_size {
             $name!(for_24x512, new_24x512, 128);
             $name!(for_24xm01, new_24xm01, 256);
             $name!(for_24xm02, new_24xm02, 256);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! for_all_ics_with_capacity {
+    ($name:ident) => {
+        mod $name {
+            use super::*;
+            $name!(for_24x00, new_24x00, 16);
+            $name!(for_24x01, new_24x01, 1 << 7);
+            $name!(for_m24x01, new_m24x01, 1 << 7);
+            $name!(for_24x02, new_24x02, 1 << 8);
+            $name!(for_m24x02, new_m24x02, 1 << 8);
+            $name!(for_24x04, new_24x04, 1 << 9);
+            $name!(for_24x08, new_24x08, 1 << 10);
+            $name!(for_24x16, new_24x16, 1 << 11);
+            $name!(for_24x32, new_24x32, 1 << 12);
+            $name!(for_24x64, new_24x64, 1 << 13);
+            $name!(for_24x128, new_24x128, 1 << 14);
+            $name!(for_24x256, new_24x256, 1 << 15);
+            $name!(for_24x512, new_24x512, 1 << 16);
+            $name!(for_24xm01, new_24xm01, 1 << 17);
+            $name!(for_24xm02, new_24xm02, 1 << 18);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! for_all_writestorage_ics_with_capacity {
+    ($name:ident) => {
+        mod $name {
+            use super::*;
+            $name!(for_24x01, new_24x01, 1 << 7);
+            $name!(for_m24x01, new_m24x01, 1 << 7);
+            $name!(for_24x02, new_24x02, 1 << 8);
+            $name!(for_m24x02, new_m24x02, 1 << 8);
+            $name!(for_24x04, new_24x04, 1 << 9);
+            $name!(for_24x08, new_24x08, 1 << 10);
+            $name!(for_24x16, new_24x16, 1 << 11);
+            $name!(for_24x32, new_24x32, 1 << 12);
+            $name!(for_24x64, new_24x64, 1 << 13);
+            $name!(for_24x128, new_24x128, 1 << 14);
+            $name!(for_24x256, new_24x256, 1 << 15);
+            $name!(for_24x512, new_24x512, 1 << 16);
+            $name!(for_24xm01, new_24xm01, 1 << 17);
+            $name!(for_24xm02, new_24xm02, 1 << 18);
         }
     };
 }

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -3,7 +3,8 @@ use embedded_hal_mock::i2c::Transaction as I2cTrans;
 mod common;
 use crate::common::{
     destroy, new_24x00, new_24x01, new_24x02, new_24x04, new_24x08, new_24x128, new_24x16,
-    new_24x256, new_24x32, new_24x512, new_24x64, new_24xm01, new_24xm02, DEV_ADDR,
+    new_24x256, new_24x32, new_24x512, new_24x64, new_24xm01, new_24xm02, new_m24x01, new_m24x02,
+    DEV_ADDR,
 };
 
 macro_rules! construction_test {

--- a/tests/invalid_address.rs
+++ b/tests/invalid_address.rs
@@ -2,7 +2,7 @@ use eeprom24x::Error;
 mod common;
 use crate::common::{
     destroy, new_24x00, new_24x01, new_24x02, new_24x04, new_24x08, new_24x128, new_24x16,
-    new_24x256, new_24x32, new_24x512, new_24x64, new_24xm01, new_24xm02,
+    new_24x256, new_24x32, new_24x512, new_24x64, new_24xm01, new_24xm02, new_m24x01, new_m24x02,
 };
 
 // only available since Rust 1.31: #[allow(clippy::needless_pass_by_value)]

--- a/tests/storage-interface.rs
+++ b/tests/storage-interface.rs
@@ -1,0 +1,113 @@
+use eeprom24x::{Eeprom24x, Error, Storage};
+use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
+use embedded_storage::{ReadStorage, Storage as _};
+mod common;
+use crate::common::{
+    destroy, new_24x00, new_24x01, new_24x02, new_24x04, new_24x08, new_24x128, new_24x16,
+    new_24x256, new_24x32, new_24x512, new_24x64, new_24xm01, new_24xm02, new_m24x01, new_m24x02,
+    DEV_ADDR,
+};
+
+struct MockCountDown;
+impl embedded_hal::timer::CountDown for MockCountDown {
+    type Time = core::time::Duration;
+    fn start<T>(&mut self, _count: T)
+    where
+        T: Into<core::time::Duration>,
+    {
+        // no-op, just mock
+    }
+    fn wait(&mut self) -> nb::Result<(), void::Void> {
+        Ok(()) // always time-out immediately, just used for busy-waiting
+    }
+}
+
+fn storage_new<PS, AS>(
+    eeprom: Eeprom24x<I2cMock, PS, AS>,
+) -> Storage<I2cMock, PS, AS, MockCountDown> {
+    Storage::new(eeprom, MockCountDown)
+}
+
+macro_rules! can_query_capacity {
+    ($name:ident, $create:ident, $capacity:expr) => {
+        #[test]
+        fn $name() {
+            let storage = storage_new($create(&[]));
+            let capacity = storage.capacity();
+            assert_eq!(capacity, $capacity);
+            destroy(storage.eeprom);
+        }
+    };
+}
+for_all_ics_with_capacity!(can_query_capacity);
+
+macro_rules! can_read_byte_1byte_addr {
+    ($name:ident, $create:ident) => {
+        #[test]
+        fn $name() {
+            let trans = [I2cTrans::write_read(DEV_ADDR, vec![0xF], vec![0xAB])];
+            let mut storage = storage_new($create(&trans));
+            let mut data = [0u8; 1];
+            storage.read(0xF, &mut data).unwrap();
+            assert_eq!(0xAB, data[0]);
+            destroy(storage.eeprom);
+        }
+    };
+}
+for_all_ics_with_1b_addr!(can_read_byte_1byte_addr);
+
+macro_rules! can_read_byte_2byte_addr {
+    ($name:ident, $create:ident) => {
+        #[test]
+        fn $name() {
+            let trans = [I2cTrans::write_read(DEV_ADDR, vec![0xF, 0x34], vec![0xAB])];
+            let mut storage = storage_new($create(&trans));
+            let mut data = [0u8; 1];
+            storage.read(0xF34, &mut data).unwrap();
+            assert_eq!(0xAB, data[0]);
+            destroy(storage.eeprom);
+        }
+    };
+}
+for_all_ics_with_2b_addr!(can_read_byte_2byte_addr);
+
+macro_rules! can_write_array_1byte_addr {
+    ($name:ident, $create:ident, $_page_size:expr) => {
+        #[test]
+        fn $name() {
+            let trans = [I2cTrans::write(DEV_ADDR, vec![0x34, 0xAB, 0xCD, 0xEF])];
+            let mut storage = storage_new($create(&trans));
+            storage.write(0x34, &[0xAB, 0xCD, 0xEF]).unwrap();
+            destroy(storage.eeprom);
+        }
+    };
+}
+for_all_ics_with_1b_addr_and_page_size!(can_write_array_1byte_addr);
+
+macro_rules! can_write_array_2byte_addr {
+    ($name:ident, $create:ident, $_page_size:expr) => {
+        #[test]
+        fn $name() {
+            let trans = [I2cTrans::write(DEV_ADDR, vec![0xF, 0x34, 0xAB, 0xCD, 0xEF])];
+            let mut storage = storage_new($create(&trans));
+            storage.write(0xF34, &[0xAB, 0xCD, 0xEF]).unwrap();
+            destroy(storage.eeprom);
+        }
+    };
+}
+for_all_ics_with_2b_addr_and_page_size!(can_write_array_2byte_addr);
+
+macro_rules! cannot_write_too_much_data {
+    ($name:ident, $create:ident, $capacity:expr) => {
+        #[test]
+        fn $name() {
+            let mut storage = storage_new($create(&[]));
+            match storage.write(0x34, &[0xAB; 1 + $capacity]) {
+                Err(Error::TooMuchData) => (),
+                _ => panic!("Error::TooMuchData not returned."),
+            }
+            destroy(storage.eeprom);
+        }
+    };
+}
+for_all_writestorage_ics_with_capacity!(cannot_write_too_much_data);


### PR DESCRIPTION
In this PR, I have done three things:

First, I have changed the `SlaveAddr::devaddr` method a little bit and added quite some documentation. When I started looking into this package, it took me a little bit to unravel what this method does and especially why it does so. In case you are happier with the old code, that is fine. But at least `(memory_address & !(1 << address_bits)) >> shift` can be replaced by the equivalent and simpler `memory_address >> shift`. And I would like to keep the comments because they would have helped me a lot in understanding why data address and device address bits are mixed combined like that (I am working with an M24C02 which does not do so).

Second, I have added ST's m24c01/02 devices. They differ from at24x01/02 in using 16 byte pages instead of 8 byte pages. To distinguish those, I have called the constructor methods `new_m24x01`. The generating macro currently requires `$dev` and `$part` for the doc string which is constructed as "Create a new instance of a M24C01 device (e.g. M24C01)". This reads a little bit weird compared to the previous doc strings, e.g. "Create a new instance of a 24x16 device (e.g. AT24C16)" but I do not know if there are other devices which are compatible with the M24C01/02 ones. So, I would personally just accept that.

Third and finally, I have implemented the `embedded_hal` traits `ReadStorage` and `Storage` which allow to access the whole memory range without taking care of pages when writing. To handle the required delay between subsequent write operations, I needed to add an `embedded_hal::timer::CountDown` dependency. To keep this out of the low-level eeprom driver, I have created another type `Storage` which combines the driver and the `CountDown`. Like this, the users can decide if they want to use the low-level interface and handle the overhead themselves or if they prefer the overhead of supplying a `CountDown`.