### PR TITLE
Reveal the MultiSizeAddr and Sealed traits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
-on:
-  push:
-  pull_request:
-
 name: Build
+on: [push, pull_request]
 
 env:
   RUSTFLAGS: '--deny warnings'
@@ -13,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.51.0]
+        rust: [stable, 1.60.0]
         TARGET:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
@@ -26,16 +23,14 @@ jobs:
           - thumbv7m-none-eabi
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.TARGET }}
-          override: true
+          targets: ${{ matrix.TARGET }}
 
       - name: Checkout CI scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'eldruin/rust-driver-ci-scripts'
           ref: 'master'
@@ -44,65 +39,35 @@ jobs:
       - run: ./ci/patch-no-std.sh
         if: ${{ ! contains(matrix.TARGET, 'x86_64') }}
 
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.TARGET }}
+      - run: cargo build --target=${{ matrix.TARGET }}
 
   checks:
     name: Checks
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable]
-        TARGET:
-          - x86_64-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.TARGET }}
-          override: true
+          targets: x86_64-unknown-linux-gnu
           components: rustfmt
 
-      - name: Doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-
-      - name: Formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo doc
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [1.54.0]
-        TARGET:
-          - x86_64-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.TARGET }}
-          override: true
+          toolchain: 1.70.0
+          targets: x86_64-unknown-linux-gnu
           components: clippy
 
-      - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo clippy --all-targets
 
   test:
     name: Tests
@@ -111,39 +76,33 @@ jobs:
       matrix:
         rust: [stable, beta]
         TARGET: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.TARGET }}
-          override: true
+          targets: ${{ matrix.TARGET }}
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=${{ matrix.TARGET }}
+        run: cargo test --target=${{ matrix.TARGET }}
+
+      - name: Build examples
+        run: cargo build --target=${{ matrix.TARGET }} --examples
 
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:latest
+      options: --security-opt seccomp=unconfined
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.18.0' # version 0.18.1 misses lots of code
-          args: '--out Lcov -- --test-threads 1'
+        run: cargo tarpaulin --out Lcov -- --test-threads 1
 
       - name: upload to Coveralls
         uses: coverallsapp/github-action@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+
+## [0.6.0] - 2023-07-10
+
 ### Added
 - Trait `Eeprom24xTrait` providing the device interface.
 
@@ -72,7 +75,8 @@ This is the initial release to crates.io of the feature-complete driver. There
 may be some API changes in the future, in case I decide that something can be
 further improved. All changes will be documented in this CHANGELOG.
 
-[Unreleased]: https://github.com/eldruin/eeprom24x-rs/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/eldruin/eeprom24x-rs/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/eldruin/eeprom24x-rs/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/eldruin/eeprom24x-rs/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/eldruin/eeprom24x-rs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/eldruin/eeprom24x-rs/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Trait `Eeprom24xTrait` providing the device interface.
+
 ## [0.5.0] - 2022-01-20
 ### Added
 - Add support for STM M24C01 and M24C02.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Trait `Eeprom24xTrait` providing the device interface.
 
+### Changed
+- Updated `embedded-storage` dependency to version 0.3.
+- Updated `nb` dependency to version 1.1.
+- Increase MSRV to version 1.60.0.
+
 ## [0.5.0] - 2022-01-20
 ### Added
 - Add support for STM M24C01 and M24C02.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eeprom24x"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Diego Barrios Romero <eldruin@gmail.com>"]
 repository = "https://github.com/eldruin/eeprom24x-rs"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,16 @@ include = [
     "/LICENSE-MIT",
     "/LICENSE-APACHE",
 ]
-edition = "2018"
-resolver = "2"
+edition = "2021"
 
 [dependencies]
-embedded-hal = "0.2"
-embedded-storage = "0.2.0"
-nb = "1.0.0"
+embedded-hal = "0.2.7"
+embedded-storage = "0.3.0"
+nb = "1.1"
 
 [dev-dependencies]
 linux-embedded-hal = "0.3"
-embedded-hal-mock = "0.8"
+embedded-hal-mock = "0.9"
 void = { version = "1.0.2", default-features = false }
 
 [profile.release]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (C) 2018-2021 Diego Barrios Romero
+Copyright (C) 2018-2023 Diego Barrios Romero
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/eeprom24x.svg)](https://crates.io/crates/eeprom24x)
 [![Docs](https://docs.rs/eeprom24x/badge.svg)](https://docs.rs/eeprom24x)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.51+-blue.svg)
+![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.60+-blue.svg)
 [![Build Status](https://github.com/eldruin/eeprom24x-rs/workflows/Build/badge.svg)](https://github.com/eldruin/eeprom24x-rs/actions?query=workflow%3ABuild)
 [![Coverage Status](https://coveralls.io/repos/eldruin/eeprom24x-rs/badge.svg?branch=master)](https://coveralls.io/r/eldruin/eeprom24x-rs?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This driver allows you to:
 - Read the current memory address (please read notes). See: `read_current_address()`.
 - Write a byte to a memory address. See: `write_byte()`.
 - Write a byte array (up to a memory page) to a memory address. See: `write_page()`.
+- Use the device in generic code via the `Eeprom24xTrait`.
 
 Can be used at least with the devices listed below.
 

--- a/examples/linux_trait.rs
+++ b/examples/linux_trait.rs
@@ -1,0 +1,30 @@
+use core::fmt::Debug;
+use eeprom24x::{Eeprom24x, Eeprom24xTrait, SlaveAddr};
+use embedded_hal::blocking::delay::DelayMs;
+use linux_embedded_hal::{Delay, I2cdev};
+
+fn run<E: Debug>(eeprom: &mut impl Eeprom24xTrait<Error = E>) {
+    let memory_address = 0x1234;
+    let data = 0xAB;
+
+    eeprom.write_byte(memory_address, data).unwrap();
+
+    Delay.delay_ms(5u16);
+
+    let read_data = eeprom.read_byte(memory_address).unwrap();
+
+    println!(
+        "Read memory address: {}, retrieved content: {}",
+        memory_address, &read_data
+    );
+}
+
+fn main() {
+    let dev = I2cdev::new("/dev/i2c-1").unwrap();
+    let address = SlaveAddr::default();
+    let mut eeprom = Eeprom24x::new_24x256(dev, address);
+
+    run(&mut eeprom);
+
+    let _dev = eeprom.destroy(); // Get the I2C device back
+}

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -1,4 +1,6 @@
-use eeprom24x::Error;
+use std::fmt::Debug;
+
+use eeprom24x::{Eeprom24xTrait, Error};
 use embedded_hal_mock::i2c::Transaction as I2cTrans;
 mod common;
 use crate::common::{
@@ -247,5 +249,17 @@ fn can_use_device_address_for_memory_addressing_2bytes() {
     let trans = [I2cTrans::write(DEV_ADDR | 0x3, vec![0xBC, 0xDE, 0xAB])];
     let mut eeprom = new_24xm02(&trans);
     eeprom.write_byte(0x3BCDE, 0xAB).unwrap();
+    destroy(eeprom);
+}
+
+fn write_byte<E: Debug>(eeprom: &mut impl Eeprom24xTrait<Error = E>) {
+    eeprom.write_byte(0x7BC, 0xAB).unwrap();
+}
+
+#[test]
+fn can_pass_device_to_function() {
+    let trans = [I2cTrans::write(DEV_ADDR | 0x7, vec![0xBC, 0xAB])];
+    let mut eeprom = new_24x16(&trans);
+    write_byte(&mut eeprom);
     destroy(eeprom);
 }


### PR DESCRIPTION
Expose traits needed to operate generically on an EEPROM. Without these traits, a user of the library may only work with fully-specified EEPROMs.