### PR TITLE
Add CSx variants (Factory-supplied unique IDs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add support for 24CSx devices.
+- Implement `read_unique_serial` for 24CSx devices.
 
 ## [0.6.0] - 2023-07-10
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This driver allows you to:
 - Read the current memory address (please read notes). See: `read_current_address()`.
 - Write a byte to a memory address. See: `write_byte()`.
 - Write a byte array (up to a memory page) to a memory address. See: `write_page()`.
+- Read `CSx`-variant devices' factory-programmed unique serial. See: `read_unique_serial()`.
 - Use the device in generic code via the `Eeprom24xTrait`.
 
 Can be used at least with the devices listed below.

--- a/src/serial_number.rs
+++ b/src/serial_number.rs
@@ -1,0 +1,52 @@
+use crate::{
+    addr_size::{OneByte, TwoBytes},
+    unique_serial, Eeprom24x, Error,
+};
+use embedded_hal::blocking::i2c::{Write, WriteRead};
+
+/// Determine the peripheral address for accessing the secure region
+/// of 24CS devices.
+fn secure_region_addr(address_bits: u8, base_addr: u8) -> u8 {
+    match address_bits {
+        7 | 8 | 12 | 13 => 0b101_1000 | (base_addr & 0b111), // CS01,CS02, CS32, CS64
+        9 => 0b101_1000 | (base_addr & 0b110),               // CS04
+        10 => 0b101_1000 | (base_addr & 0b100),              // CS08
+        11 => 0b101_1000,                                    // CS16
+        _ => unreachable!(),
+    }
+}
+
+/// Methods for interacting with the factory-programmed unique serial number
+/// for devices with one byte addresses. e.g. 24CSx01, 24CSx02,24CSx04, 24CSx08,
+/// and 24CSx16.
+impl<I2C, PS, E> Eeprom24x<I2C, PS, OneByte, unique_serial::Yes>
+where
+    I2C: Write<Error = E> + WriteRead<Error = E>,
+{
+    /// Read the 128-bit unique serial number.
+    pub fn read_unique_serial(&mut self) -> Result<[u8; 16], Error<E>> {
+        let addr = secure_region_addr(self.address_bits, self.address.addr());
+        let mut serial_bytes = [0u8; 16];
+        self.i2c
+            .write_read(addr, &[0x80], &mut serial_bytes)
+            .map_err(Error::I2C)?;
+        Ok(serial_bytes)
+    }
+}
+
+/// Methods for interacting with the factory-programmed unique serial number
+/// for devices with two byte addresses. e.g. 24CSx32 and 24CSx64
+impl<I2C, PS, E> Eeprom24x<I2C, PS, TwoBytes, unique_serial::Yes>
+where
+    I2C: Write<Error = E> + WriteRead<Error = E>,
+{
+    /// Read the 128-bit unique serial number.
+    pub fn read_unique_serial(&mut self) -> Result<[u8; 16], Error<E>> {
+        let secure_region_addr = 0b101_1000 | (self.address.addr() & 0b111);
+        let mut serial_bytes = [0u8; 16];
+        self.i2c
+            .write_read(secure_region_addr, &[0x08, 0x0], &mut serial_bytes)
+            .map_err(Error::I2C)?;
+        Ok(serial_bytes)
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -10,15 +10,15 @@ use embedded_hal::{
 use embedded_storage::ReadStorage;
 
 /// Common methods
-impl<I2C, PS, AS, CD> Storage<I2C, PS, AS, CD> {}
+impl<I2C, PS, AS, SN, CD> Storage<I2C, PS, AS, SN, CD> {}
 
 /// Common methods
-impl<I2C, PS, AS, CD> Storage<I2C, PS, AS, CD>
+impl<I2C, PS, AS, SN, CD> Storage<I2C, PS, AS, SN, CD>
 where
     CD: CountDown<Time = Duration>,
 {
     /// Create a new Storage instance wrapping the given Eeprom
-    pub fn new(eeprom: Eeprom24x<I2C, PS, AS>, mut count_down: CD) -> Self {
+    pub fn new(eeprom: Eeprom24x<I2C, PS, AS, SN>, mut count_down: CD) -> Self {
         // When writing to the eeprom, we start a countdown of 5 ms after each page and wait for
         // the timer before writing to the next page. Therefore, we always need a valid countdown
         // so we start it here without any delay.
@@ -31,14 +31,14 @@ where
 }
 
 /// Common methods
-impl<I2C, PS, AS, CD> Storage<I2C, PS, AS, CD> {
+impl<I2C, PS, AS, SN, CD> Storage<I2C, PS, AS, SN, CD> {
     /// Destroy driver instance, return I²C bus and timer instance.
     pub fn destroy(self) -> (I2C, CD) {
         (self.eeprom.destroy(), self.count_down)
     }
 }
 
-impl<I2C, E, PS, AS, CD> embedded_storage::ReadStorage for Storage<I2C, PS, AS, CD>
+impl<I2C, E, PS, AS, SN, CD> embedded_storage::ReadStorage for Storage<I2C, PS, AS, SN, CD>
 where
     I2C: Write<Error = E> + WriteRead<Error = E>,
     AS: MultiSizeAddr,
@@ -57,11 +57,11 @@ where
     }
 }
 
-impl<I2C, E, PS, AS, CD> embedded_storage::Storage for Storage<I2C, PS, AS, CD>
+impl<I2C, E, PS, AS, SN, CD> embedded_storage::Storage for Storage<I2C, PS, AS, SN, CD>
 where
     I2C: Write<Error = E> + WriteRead<Error = E>,
     AS: MultiSizeAddr,
-    Eeprom24x<I2C, PS, AS>: PageWrite<E>,
+    Eeprom24x<I2C, PS, AS, SN>: PageWrite<E>,
     CD: CountDown<Time = Duration>,
 {
     fn write(&mut self, mut offset: u32, mut bytes: &[u8]) -> Result<(), Self::Error> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,38 +1,46 @@
-use eeprom24x::{addr_size, page_size, Eeprom24x, SlaveAddr};
+use eeprom24x::{addr_size, page_size, unique_serial, Eeprom24x, SlaveAddr};
 use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 
 #[allow(unused)]
 pub const DEV_ADDR: u8 = 0b101_0000;
 
 macro_rules! create {
-    ($create:ident, $AS:ident, $PS:ident) => {
+    ($create:ident, $AS:ident, $PS:ident, $SN:ident) => {
+        #[allow(dead_code)]
         pub fn $create(
             transactions: &[I2cTrans],
-        ) -> Eeprom24x<I2cMock, page_size::$PS, addr_size::$AS> {
+        ) -> Eeprom24x<I2cMock, page_size::$PS, addr_size::$AS, unique_serial::$SN> {
             Eeprom24x::$create(I2cMock::new(transactions), SlaveAddr::default())
         }
     };
 }
 
-pub fn destroy<T, V>(eeprom: Eeprom24x<I2cMock, T, V>) {
+pub fn destroy<T, V, S>(eeprom: Eeprom24x<I2cMock, T, V, S>) {
     eeprom.destroy().done();
 }
 
-create!(new_24x00, OneByte, No);
-create!(new_24x01, OneByte, B8);
-create!(new_m24x01, OneByte, B16);
-create!(new_24x02, OneByte, B8);
-create!(new_m24x02, OneByte, B16);
-create!(new_24x04, OneByte, B16);
-create!(new_24x08, OneByte, B16);
-create!(new_24x16, OneByte, B16);
-create!(new_24x32, TwoBytes, B32);
-create!(new_24x64, TwoBytes, B32);
-create!(new_24x128, TwoBytes, B64);
-create!(new_24x256, TwoBytes, B64);
-create!(new_24x512, TwoBytes, B128);
-create!(new_24xm01, TwoBytes, B256);
-create!(new_24xm02, TwoBytes, B256);
+create!(new_24x00, OneByte, No, No);
+create!(new_24x01, OneByte, B8, No);
+create!(new_24csx01, OneByte, B8, Yes);
+create!(new_m24x01, OneByte, B16, No);
+create!(new_24x02, OneByte, B8, No);
+create!(new_24csx02, OneByte, B8, Yes);
+create!(new_m24x02, OneByte, B16, No);
+create!(new_24x04, OneByte, B16, No);
+create!(new_24csx04, OneByte, B16, Yes);
+create!(new_24x08, OneByte, B16, No);
+create!(new_24csx08, OneByte, B16, Yes);
+create!(new_24x16, OneByte, B16, No);
+create!(new_24csx16, OneByte, B16, Yes);
+create!(new_24x32, TwoBytes, B32, No);
+create!(new_24csx32, TwoBytes, B32, Yes);
+create!(new_24x64, TwoBytes, B32, No);
+create!(new_24csx64, TwoBytes, B32, Yes);
+create!(new_24x128, TwoBytes, B64, No);
+create!(new_24x256, TwoBytes, B64, No);
+create!(new_24x512, TwoBytes, B128, No);
+create!(new_24xm01, TwoBytes, B256, No);
+create!(new_24xm02, TwoBytes, B256, No);
 
 #[macro_export]
 macro_rules! for_all_ics {
@@ -41,14 +49,21 @@ macro_rules! for_all_ics {
             use super::*;
             $name!(for_24x00, new_24x00);
             $name!(for_24x01, new_24x01);
+            $name!(for_24csx01, new_24csx01);
             $name!(for_m24x01, new_m24x01);
             $name!(for_24x02, new_24x02);
+            $name!(for_24csx02, new_24csx02);
             $name!(for_m24x02, new_m24x02);
             $name!(for_24x04, new_24x04);
+            $name!(for_24csx04, new_24csx04);
             $name!(for_24x08, new_24x08);
+            $name!(for_24csx08, new_24csx08);
             $name!(for_24x16, new_24x16);
+            $name!(for_24csx16, new_24csx16);
             $name!(for_24x32, new_24x32);
+            $name!(for_24csx32, new_24csx32);
             $name!(for_24x64, new_24x64);
+            $name!(for_24csx64, new_24csx64);
             $name!(for_24x128, new_24x128);
             $name!(for_24x256, new_24x256);
             $name!(for_24x512, new_24x512);
@@ -65,12 +80,17 @@ macro_rules! for_all_ics_with_1b_addr {
             use super::*;
             $name!(for_24x00, new_24x00);
             $name!(for_24x01, new_24x01);
+            $name!(for_24csx01, new_24csx01);
             $name!(for_m24x01, new_m24x01);
             $name!(for_24x02, new_24x02);
+            $name!(for_24csx02, new_24csx02);
             $name!(for_m24x02, new_m24x02);
             $name!(for_24x04, new_24x04);
+            $name!(for_24csx04, new_24csx04);
             $name!(for_24x08, new_24x08);
+            $name!(for_24csx08, new_24csx08);
             $name!(for_24x16, new_24x16);
+            $name!(for_24csx16, new_24csx16);
         }
     };
 }
@@ -81,7 +101,9 @@ macro_rules! for_all_ics_with_2b_addr {
         mod $name {
             use super::*;
             $name!(for_24x32, new_24x32);
+            $name!(for_24csx32, new_24csx32);
             $name!(for_24x64, new_24x64);
+            $name!(for_24csx64, new_24csx64);
             $name!(for_24x128, new_24x128);
             $name!(for_24x256, new_24x256);
             $name!(for_24x512, new_24x512);
@@ -97,12 +119,17 @@ macro_rules! for_all_ics_with_1b_addr_and_page_size {
         mod $name {
             use super::*;
             $name!(for_24x01, new_24x01, 8);
+            $name!(for_24csx01, new_24csx01, 8);
             $name!(for_m24x01, new_m24x01, 16);
             $name!(for_24x02, new_24x02, 8);
+            $name!(for_24csx02, new_24csx02, 8);
             $name!(for_m24x02, new_m24x02, 16);
             $name!(for_24x04, new_24x04, 16);
+            $name!(for_24csx04, new_24csx04, 16);
             $name!(for_24x08, new_24x08, 16);
+            $name!(for_24csx08, new_24csx08, 16);
             $name!(for_24x16, new_24x16, 16);
+            $name!(for_24csx16, new_24csx16, 16);
         }
     };
 }
@@ -113,7 +140,9 @@ macro_rules! for_all_ics_with_2b_addr_and_page_size {
         mod $name {
             use super::*;
             $name!(for_24x32, new_24x32, 32);
+            $name!(for_24csx32, new_24csx32, 32);
             $name!(for_24x64, new_24x64, 32);
+            $name!(for_24csx64, new_24csx64, 32);
             $name!(for_24x128, new_24x128, 64);
             $name!(for_24x256, new_24x256, 64);
             $name!(for_24x512, new_24x512, 128);
@@ -129,14 +158,21 @@ macro_rules! for_all_ics_with_page_size {
         mod $name {
             use super::*;
             $name!(for_24x01, new_24x01, 8);
+            $name!(for_24csx01, new_24csx01, 8);
             $name!(for_m24x01, new_m24x01, 16);
             $name!(for_24x02, new_24x02, 8);
+            $name!(for_24csx02, new_24csx02, 8);
             $name!(for_m24x02, new_m24x02, 16);
             $name!(for_24x04, new_24x04, 16);
+            $name!(for_24csx04, new_24csx04, 16);
             $name!(for_24x08, new_24x08, 16);
+            $name!(for_24csx08, new_24csx08, 16);
             $name!(for_24x16, new_24x16, 16);
+            $name!(for_24csx16, new_24csx16, 16);
             $name!(for_24x32, new_24x32, 32);
+            $name!(for_24csx32, new_24csx32, 32);
             $name!(for_24x64, new_24x64, 32);
+            $name!(for_24csx64, new_24csx64, 32);
             $name!(for_24x128, new_24x128, 64);
             $name!(for_24x256, new_24x256, 64);
             $name!(for_24x512, new_24x512, 128);
@@ -153,14 +189,21 @@ macro_rules! for_all_ics_with_capacity {
             use super::*;
             $name!(for_24x00, new_24x00, 16);
             $name!(for_24x01, new_24x01, 1 << 7);
+            $name!(for_24csx01, new_24csx01, 1 << 7);
             $name!(for_m24x01, new_m24x01, 1 << 7);
             $name!(for_24x02, new_24x02, 1 << 8);
+            $name!(for_24csx02, new_24csx02, 1 << 8);
             $name!(for_m24x02, new_m24x02, 1 << 8);
             $name!(for_24x04, new_24x04, 1 << 9);
+            $name!(for_24csx04, new_24csx04, 1 << 9);
             $name!(for_24x08, new_24x08, 1 << 10);
+            $name!(for_24csx08, new_24csx08, 1 << 10);
             $name!(for_24x16, new_24x16, 1 << 11);
+            $name!(for_24csx16, new_24csx16, 1 << 11);
             $name!(for_24x32, new_24x32, 1 << 12);
+            $name!(for_24csx32, new_24csx32, 1 << 12);
             $name!(for_24x64, new_24x64, 1 << 13);
+            $name!(for_24csx64, new_24csx64, 1 << 13);
             $name!(for_24x128, new_24x128, 1 << 14);
             $name!(for_24x256, new_24x256, 1 << 15);
             $name!(for_24x512, new_24x512, 1 << 16);
@@ -176,19 +219,51 @@ macro_rules! for_all_writestorage_ics_with_capacity {
         mod $name {
             use super::*;
             $name!(for_24x01, new_24x01, 1 << 7);
+            $name!(for_24csx01, new_24csx01, 1 << 7);
             $name!(for_m24x01, new_m24x01, 1 << 7);
             $name!(for_24x02, new_24x02, 1 << 8);
+            $name!(for_24csx02, new_24csx02, 1 << 8);
             $name!(for_m24x02, new_m24x02, 1 << 8);
             $name!(for_24x04, new_24x04, 1 << 9);
+            $name!(for_24csx04, new_24csx04, 1 << 9);
             $name!(for_24x08, new_24x08, 1 << 10);
+            $name!(for_24csx08, new_24csx08, 1 << 10);
             $name!(for_24x16, new_24x16, 1 << 11);
+            $name!(for_24csx16, new_24csx16, 1 << 11);
             $name!(for_24x32, new_24x32, 1 << 12);
+            $name!(for_24csx32, new_24csx32, 1 << 12);
             $name!(for_24x64, new_24x64, 1 << 13);
+            $name!(for_24csx64, new_24csx64, 1 << 13);
             $name!(for_24x128, new_24x128, 1 << 14);
             $name!(for_24x256, new_24x256, 1 << 15);
             $name!(for_24x512, new_24x512, 1 << 16);
             $name!(for_24xm01, new_24xm01, 1 << 17);
             $name!(for_24xm02, new_24xm02, 1 << 18);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! for_all_with_serial_with_1b_addr {
+    ($name:ident) => {
+        mod $name {
+            use super::*;
+            $name!(for_24csx01, new_24csx01);
+            $name!(for_24csx02, new_24csx02);
+            $name!(for_24csx04, new_24csx04);
+            $name!(for_24csx08, new_24csx08);
+            $name!(for_24csx16, new_24csx16);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! for_all_with_serial_with_2b_addr {
+    ($name:ident) => {
+        mod $name {
+            use super::*;
+            $name!(for_24csx32, new_24csx32);
+            $name!(for_24csx64, new_24csx64);
         }
     };
 }

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -4,7 +4,8 @@ use eeprom24x::{Eeprom24xTrait, Error};
 use embedded_hal_mock::i2c::Transaction as I2cTrans;
 mod common;
 use crate::common::{
-    destroy, new_24x00, new_24x01, new_24x02, new_24x04, new_24x08, new_24x128, new_24x16,
+    destroy, new_24csx01, new_24csx02, new_24csx04, new_24csx08, new_24csx16, new_24csx32,
+    new_24csx64, new_24x00, new_24x01, new_24x02, new_24x04, new_24x08, new_24x128, new_24x16,
     new_24x256, new_24x32, new_24x512, new_24x64, new_24xm01, new_24xm02, new_m24x01, new_m24x02,
     DEV_ADDR,
 };

--- a/tests/invalid_address.rs
+++ b/tests/invalid_address.rs
@@ -1,7 +1,8 @@
 use eeprom24x::Error;
 mod common;
 use crate::common::{
-    destroy, new_24x00, new_24x01, new_24x02, new_24x04, new_24x08, new_24x128, new_24x16,
+    destroy, new_24csx01, new_24csx02, new_24csx04, new_24csx08, new_24csx16, new_24csx32,
+    new_24csx64, new_24x00, new_24x01, new_24x02, new_24x04, new_24x08, new_24x128, new_24x16,
     new_24x256, new_24x32, new_24x512, new_24x64, new_24xm01, new_24xm02, new_m24x01, new_m24x02,
 };
 

--- a/tests/serial_number.rs
+++ b/tests/serial_number.rs
@@ -1,0 +1,49 @@
+use embedded_hal_mock::i2c::Transaction as I2cTrans;
+mod common;
+use crate::common::{
+    destroy, new_24csx01, new_24csx02, new_24csx04, new_24csx08, new_24csx16, new_24csx32,
+    new_24csx64,
+};
+
+#[allow(unused)]
+pub const DEV_SERIAL: [u8; 16] = [
+    0xDE, 0xAD, 0xBE, 0xEF, 0xB0, 0xBA, 0xCA, 0xFE, 0xFE, 0xED, 0xC0, 0xDE, 0x1, 0x2, 0x3, 0x4,
+];
+
+macro_rules! can_read_serial_number_1byte_addr {
+    ($name:ident, $create:ident) => {
+        #[test]
+        fn $name() {
+            let trans = [I2cTrans::write_read(
+                0b101_1000,
+                vec![0x80],
+                DEV_SERIAL.to_vec(),
+            )];
+            let mut eeprom = $create(&trans);
+            let serial_number = eeprom.read_unique_serial().unwrap();
+            assert_eq!(DEV_SERIAL, serial_number);
+            destroy(eeprom);
+        }
+    };
+}
+
+for_all_with_serial_with_1b_addr!(can_read_serial_number_1byte_addr);
+
+macro_rules! can_read_serial_number_2byte_addr {
+    ($name:ident, $create:ident) => {
+        #[test]
+        fn $name() {
+            let trans = [I2cTrans::write_read(
+                0b101_1000,
+                vec![0x8, 0x0],
+                DEV_SERIAL.to_vec(),
+            )];
+            let mut eeprom = $create(&trans);
+            let serial_number = eeprom.read_unique_serial().unwrap();
+            assert_eq!(DEV_SERIAL, serial_number);
+            destroy(eeprom);
+        }
+    };
+}
+
+for_all_with_serial_with_2b_addr!(can_read_serial_number_2byte_addr);

--- a/tests/storage-interface.rs
+++ b/tests/storage-interface.rs
@@ -3,7 +3,8 @@ use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 use embedded_storage::{ReadStorage, Storage as _};
 mod common;
 use crate::common::{
-    destroy, new_24x00, new_24x01, new_24x02, new_24x04, new_24x08, new_24x128, new_24x16,
+    destroy, new_24csx01, new_24csx02, new_24csx04, new_24csx08, new_24csx16, new_24csx32,
+    new_24csx64, new_24x00, new_24x01, new_24x02, new_24x04, new_24x08, new_24x128, new_24x16,
     new_24x256, new_24x32, new_24x512, new_24x64, new_24xm01, new_24xm02, new_m24x01, new_m24x02,
     DEV_ADDR,
 };
@@ -22,9 +23,9 @@ impl embedded_hal::timer::CountDown for MockCountDown {
     }
 }
 
-fn storage_new<PS, AS>(
-    eeprom: Eeprom24x<I2cMock, PS, AS>,
-) -> Storage<I2cMock, PS, AS, MockCountDown> {
+fn storage_new<PS, AS, SN>(
+    eeprom: Eeprom24x<I2cMock, PS, AS, SN>,
+) -> Storage<I2cMock, PS, AS, SN, MockCountDown> {
     Storage::new(eeprom, MockCountDown)
 }
 


### PR DESCRIPTION
Will fix #15 

## Summary
This PR adds support for the Unique ID EEPROMs in the 24x series.

11 parts from Microchip support this feature found [here](https://www.microchip.com/en-us/products/memory/serial-eeprom/mac-address-and-unique-id-eeproms).

Here are their datasheets:
- [AT24CS0[1|2]](https://ww1.microchip.com/downloads/aemDocuments/documents/MPD/ProductDocuments/DataSheets/20006330A.pdf)
- [AT24CSW0[1|2]x](https://ww1.microchip.com/downloads/aemDocuments/documents/MPD/ProductDocuments/DataSheets/AT24CSW01X-AT24XSW02X-I2C-Compatible-%28Two-Wire%29-Serial-EEPROM-with-a-Security-Register-and-Software-Write-Protection-1-Kbit-%28128X8%29-2-Kbit-%28256X8%29-20006396B.pdf)
- [AT24CS0[4|8]](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/20006350A.pdf)
- [AT24CSW0[4|8]](https://ww1.microchip.com/downloads/aemDocuments/documents/MPD/ProductDocuments/DataSheets/AT24CSW04X-AT24CSW08X-I2C-Compatible-%28Two-Wire%29-Serial-EEPROM-with-a-Security-Register-and-Software-Write-Protection-4-Kbit-8-Kbit-20006426B.pdf)
- [AT24CS16](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/20006342A.pdf)
- [AT24CS32](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/20006341A.pdf)
- [AT24CS64](https://ww1.microchip.com/downloads/aemDocuments/documents/MCU08/ProductDocuments/DataSheets/20006296A.pdf)

These parts work by adding *another* valid device address to the bus that provides access to a "security register." This register contains just the 128-bit unique serial number for non-W variant devices. For the W-variant devices, there is quite a lot of complexity in adding write protection and blowing fuses for write-once data. That functionality is not implemented in this PR; however, the access mechanism for the serial number is the same across both variants.

## Things I'd like help with
### Macros
Adding the marker type for having a unique ID makes the macro generation of the constructors quite tricky. Before, those macros generate an impl block for devices with the same page size. Between devices, the only variant was the number of address bits, which wasn't tracked by a marker type. Now, however, we need to add one, which makes the single impl block incorrect. I patched this temporarily with
```rust
 $(
impl<I2C, E> Eeprom24x<I2C, page_size::$PS, addr_size::$AS, unique_serial::$SN>
where
    I2C: Write<Error = E>
{
    impl_create!($dev, $part, $address_bits, $create);
}
)*
```
but that makes the macro-exapanded result a little messy. There is probably a nicer way to do this, but it always takes me so long to grok macros.
### Device addressing
Currently, the peripheral address is determined with
```rust
pub(crate) fn addr(self) -> u8 {
    match self {
        SlaveAddr::Default => 0b101_0000,
        SlaveAddr::Alternative(a2, a1, a0) => {
            SlaveAddr::default().addr() | ((a2 as u8) << 2) | ((a1 as u8) << 1) | a0 as u8
        }
    }
}
```
This is correct when accessing main memory, but accessing the security register needs a different "device type identifier". This is what the datasheets call that `0b1010` preamble to the address. For the security register, this device type identifier is `0b1011`, with various rules depending on the particular part on how to construct the remainder of the address.

My implementation just adds a new private function `secure_region_addr` to compute it, but we may want to work this into `SlaveAddr` directly to eventually support accessing the security registers in the W-variant parts.

I look forward to your feedback!