### PR TITLE
Add support for Microchip 2K EEPROMs 24AA02E48/24AA025E48/ 24AA02E64/24AA025E64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Add support for 24AAxE48/E64 devices.
+- Add support for 24AA02xE48/E64 devices.
 
 ## [0.6.1] - 2023-12-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Added
+- Add support for 24AA02xE48/E64 devices.
+
 ## [0.7.0] - 2024-01-18
 
 ### Changed
@@ -15,7 +18,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   use the new `embedded-hal` `DelayNs` trait instead of the old `CountDown`
 - [breaking-change] Transitioned `embedded-hal` to version 1.0
 - Updated `embedded-storage` to version 0.3.1
-- Add support for 24AA02xE48/E64 devices.
 
 ## [0.6.1] - 2023-12-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add support for 24AAxE48/E64 devices.
 
 ## [0.6.1] - 2023-12-27
 

--- a/src/eeprom24x.rs
+++ b/src/eeprom24x.rs
@@ -321,8 +321,8 @@ impl_for_page_size!(
     ["24CSx04", "AT24CS04", 9, Yes, new_24csx04],
     ["24CSx08", "AT24CS08", 10, Yes, new_24csx08],
     ["24CSx16", "AT24CS16", 11, Yes, new_24csx16],
-    ["24AAx025E48", "24AA025E48", 8, No, new_24aax025e48],
-    ["24AAx025E64", "24AA025E64", 8, No, new_24aax025e64],
+    ["24x025E48", "24AA025E48", 8, No, new_24x025e48],
+    ["24x025E64", "24AA025E64", 8, No, new_24x025e64],
     ["M24C01", "M24C01", 7, No, new_m24x01],
     ["M24C02", "M24C02", 8, No, new_m24x02]
 );

--- a/src/eeprom24x.rs
+++ b/src/eeprom24x.rs
@@ -307,8 +307,8 @@ impl_for_page_size!(
     ["24x02", "AT24C02", 8, No, new_24x02],
     ["24CSx01", "24CS01", 7, Yes, new_24csx01],
     ["24CSx02", "24CS02", 8, Yes, new_24csx02],
-    ["24AAx02E48", "24AA02E48", 8, No, new_24aax02e48],
-    ["24AAx02E64", "24AA02E64", 8, No, new_24aax02e64]
+    ["24x02E48", "24AA02E48", 8, No, new_24x02e48],
+    ["24x02E64", "24AA02E64", 8, No, new_24x02e64]
 );
 impl_for_page_size!(
     OneByte,

--- a/src/eeprom24x.rs
+++ b/src/eeprom24x.rs
@@ -306,7 +306,9 @@ impl_for_page_size!(
     ["24x01", "AT24C01", 7, No, new_24x01],
     ["24x02", "AT24C02", 8, No, new_24x02],
     ["24CSx01", "24CS01", 7, Yes, new_24csx01],
-    ["24CSx02", "24CS02", 8, Yes, new_24csx02]
+    ["24CSx02", "24CS02", 8, Yes, new_24csx02],
+    ["24AAx02E48", "24AA02E48", 8, No, new_24aax02e48],
+    ["24AAx02E64", "24AA02E64", 8, No, new_24aax02e64]
 );
 impl_for_page_size!(
     OneByte,
@@ -319,6 +321,8 @@ impl_for_page_size!(
     ["24CSx04", "AT24CS04", 9, Yes, new_24csx04],
     ["24CSx08", "AT24CS08", 10, Yes, new_24csx08],
     ["24CSx16", "AT24CS16", 11, Yes, new_24csx16],
+    ["24AAx025E48", "24AA025E48", 8, No, new_24aax025e48],
+    ["24AAx025E64", "24AA025E64", 8, No, new_24aax025e64],
     ["M24C01", "M24C01", 7, No, new_m24x01],
     ["M24C02", "M24C02", 8, No, new_m24x02]
 );


### PR DESCRIPTION
This PR adds the four variants of the EEPROMs in the 24AA02 series. Later I will create another PR that implements reading out the EUI-48 and EUI-64 node identities (similar to unique serial number but used for MAC addresses).

Reference datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/24AA02E48-24AA025E48-24AA02E64-24AA025E64-Data-Sheet-20002124H.pdf

Have tested on a 24AA02E48.
