### PR TITLE
Add feature-gated support for defmt::Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add feature defmt-03
-- When feature enabled, "defmt::Format" is derived for any public struct or enum that derives Debug.
+- Add feature `defmt-03` to derive "`defmt::Format`" from `defmt = "0.3"` for public types.
 
 ## [0.7.1] - 2024-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+## [0.7.2] - 2024-05-16
+
+### Added
+
+- Add feature defmt-03
+- When feature enabled, "defmt::Format" is derived for any public struct or enum that derives Debug.
+
 ## [0.7.1] - 2024-05-02
 
 ### Added
+
 - Add support for 24AA02xE48/E64 devices.
 - Add `Debug` derive to markers.
 
 ## [0.7.0] - 2024-01-18
 
 ### Changed
+
 - [breaking-change] Transitioned the `embedded-storage` interface to
   use the new `embedded-hal` `DelayNs` trait instead of the old `CountDown`
 - [breaking-change] Transitioned `embedded-hal` to version 1.0
@@ -25,58 +34,75 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.6.1] - 2023-12-27
 
 ### Added
+
 - Add support for 24CSx devices.
 - Implement `read_unique_serial` for 24CSx devices.
 
 ## [0.6.0] - 2023-07-10
 
 ### Added
+
 - Trait `Eeprom24xTrait` providing the device interface.
 
 ### Changed
+
 - Updated `embedded-storage` dependency to version 0.3.
 - Updated `nb` dependency to version 1.1.
 - Increase MSRV to version 1.60.0.
 
 ## [0.5.0] - 2022-01-20
+
 ### Added
+
 - Add support for STM M24C01 and M24C02.
 - Implement `embedded_storage::ReadStorage` and `embedded_storage::Storage` traits.
 
 ### Changed
+
 - [breaking-change] Increase MSRV to version 1.51.0.
 
 ## [0.4.0] - 2021-09-04
+
 ### Added
+
 - `PartialEq` implementation for `SlaveAddr`.
 
 ### Changed
+
 - [breaking-change] Remove `Default` derive for `Eeprom24x`.
   Technically a breaking change but it should not affect anybody.
 
 ## [0.3.0] - 2019-01-20
+
 ### Changed
+
 - [breaking-change] The addresses are now passed as a single `u32`.
 User code should be easy to adapt:
 `eeprom.read_byte([0x12, 0x34])` now becomes: `eeprom.read_byte(0x1234)`.
 
 ### Fixed
+
 - High memory addressing in devices using some device address bits for memory
 addressing: `24x04`, `24x08`, `24x16`, `24xM01`, `24xM02`.
 - Protect against memory address rollover.
 - Protect against page address rollover.
 
 ## [0.2.1] - 2019-01-20
+
 ### Removed
+
 - [breaking-change] Removed support for devices that use some device address
 bits for memory addressing: `24x04`, `24x08`, `24x16`, `24xM01`, `24xM02` as
 the addressing was erroneous. Please upgrade to version `0.3.0` to use them.
 
 ## [0.2.0] - 2018-11-22
+
 ### Added
+
 - Add support for many more devices.
 
 ### Changed
+
 - [breaking-change] The addresses are now passed to the methods per value for
 efficiency reasons. i.e. `address: &[u8; 2]` has now become `address: [u8; 2]`
 in all methods. User code should be easy to adapt:
@@ -86,7 +112,9 @@ in all methods. User code should be easy to adapt:
 is a marker type for the page size instead of the device name.
 
 ## [0.1.1] - 2018-08-22
+
 ### Fixed
+
 - Disallow setting a different slave address through `SlaveAddr::Default`.
 
 ## 0.1.0 - 2018-08-18

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eeprom24x"
-version = "0.7.2"
+version = "0.7.1"
 authors = ["Diego Barrios Romero <eldruin@gmail.com>"]
 repository = "https://github.com/eldruin/eeprom24x-rs"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eeprom24x"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Diego Barrios Romero <eldruin@gmail.com>"]
 repository = "https://github.com/eldruin/eeprom24x-rs"
 license = "MIT OR Apache-2.0"
@@ -21,7 +21,7 @@ include = [
 edition = "2021"
 
 [features]
-defmt = ["dep:defmt"]
+defmt-03 = ["dep:defmt"]
 
 [dependencies]
 embedded-hal = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 edition = "2021"
 
 [features]
-defmt-03 = ["dep:defmt"]
+defmt-03 = ["dep:defmt", "embedded-hal/defmt-03"]
 
 [dependencies]
 embedded-hal = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,13 @@ include = [
 ]
 edition = "2021"
 
+[features]
+defmt = ["dep:defmt"]
+
 [dependencies]
 embedded-hal = "1"
 embedded-storage = "0.3.1"
+defmt = { version = "0.3.6", optional = true }
 
 [dev-dependencies]
 linux-embedded-hal = "0.4"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ based on the [`embedded-hal`] traits.
 [`embedded-hal`]: https://github.com/rust-embedded/embedded-hal
 
 This driver allows you to:
+
 - Read a single byte from a memory address. See: `read_byte()`.
 - Read a byte array starting on a memory address. See: `read_data()`.
 - Read the current memory address (please read notes). See: `read_current_address()`.
@@ -25,6 +26,7 @@ Can be used at least with the devices listed below.
 [Introductory blog post](https://blog.eldruin.com/24x-serial-eeprom-driver-in-rust/)
 
 ## The devices
+
 These devices provides a number of bits of serial electrically erasable and
 programmable read only memory (EEPROM) organized as a number of words of 8 bits
 each. The devices' cascadable feature allows up to 8 devices to share a common
@@ -104,6 +106,44 @@ fn main() {
 }
 ```
 
+## Features
+
+### defmt-03
+
+defmt ("de format", short for "deferred formatting") is a highly efficient logging framework that targets resource-constrained devices, like microcontrollers. Learn more about defmt at [https://defmt.ferrous-systems.com].
+
+When feature "defmt-03" is enabled for the eeprom24x-rs dependency, defmt::Format is derived for all public struct and enum definitions. This allows (deferred-)formatting of data for logging and other reporting using the defmt crate. Data from the eeprom24x crate can then be logged alongside any other defmt-supported data using the normal defmt statements.
+
+To enable defmt support, when specifying a dependency on eeprom24x, add the feature "defmt-03"
+
+```toml
+[dependencies]
+eeprom24x = { version = "0.7.2", features = ["defmt-03"] }
+```
+
+#### defmt-03 usage
+
+```rust
+use eeprom24x::{Eeprom24x, SlaveAddr};
+use embedded_hal::blocking::delay::DelayMs;
+use linux_embedded_hal::{Delay, I2cdev};
+
+fn main() {
+    let dev = I2cdev::new("/dev/i2c-1").unwrap();
+    let address = SlaveAddr::default();
+    let mut eeprom = Eeprom24x::new_24x256(dev, address);
+    let memory_address = 0x1234;
+    let data = 0xAB;
+
+    if let Err(e) = eeprom.write_byte(memory_address, data) {
+        defmt::error!("eeprom.write_byte error {:?}", e);
+        // panic or other error handling here...
+    }
+
+    let _dev = eeprom.destroy(); // Get the I2C device back
+}
+```
+
 ## Support
 
 For questions, issues, feature requests, and other changes, please file an
@@ -113,10 +153,10 @@ For questions, issues, feature requests, and other changes, please file an
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+   <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@
 use core::marker::PhantomData;
 
 /// All possible errors in this crate
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug)]
 pub enum Error<E> {
     /// I²C bus error
@@ -178,6 +179,7 @@ pub enum Error<E> {
 ///
 /// Note that in some devices some of the address bits are used for memory addressing and
 /// will therefore be ignored.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SlaveAddr {
     /// Default slave address
@@ -197,10 +199,12 @@ pub enum SlaveAddr {
 pub mod addr_size {
     /// 1-byte memory address.
     /// e.g. for AT24x00, AT24x01, AT24x02, AT24x04, AT24x08, AT24x16
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct OneByte(());
     /// 2-byte memory address.
     /// e.g. for AT24x32, AT24x64, AT24x128, AT24x256, AT24x512, AT24xM01, AT24xM02
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct TwoBytes(());
 }
@@ -208,24 +212,31 @@ pub mod addr_size {
 /// Page size markers
 pub mod page_size {
     /// No page write supported. e.g. for AT24x00
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct No(());
     /// 8-byte pages. e.g. for AT24x01, AT24x02
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B8(());
     /// 16-byte pages. e.g. for AT24x04, AT24x08, AT24x16
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B16(());
     /// 32-byte pages. e.g. for AT24x32, AT24x64
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B32(());
     /// 64-byte pages. e.g. for AT24x128, AT24x256
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B64(());
     /// 128-byte pages. e.g. for AT24x512
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B128(());
     /// 256-byte pages. e.g. for AT24xM01, AT24xM02
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B256(());
 }
@@ -233,14 +244,17 @@ pub mod page_size {
 /// Factory-supplied unique serial number markers
 pub mod unique_serial {
     /// Contains a factory-supplied unique serial number. e.g. for AT24CSx
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct Yes(());
     /// No factory-supplied unique serial number
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct No(());
 }
 
 /// EEPROM24X driver
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug)]
 pub struct Eeprom24x<I2C, PS, AS, SN> {
     /// The concrete I²C device implementation.
@@ -300,6 +314,7 @@ pub trait Eeprom24xTrait: private::Sealed {
 
 /// EEPROM24X extension which supports the `embedded-storage` traits but requires an
 /// `embedded_hal::delay::DelayNs` to handle the timeouts when writing over page boundaries
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug)]
 pub struct Storage<I2C, PS, AS, SN, D> {
     /// Eeprom driver over which we implement the Storage traits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@
 use core::marker::PhantomData;
 
 /// All possible errors in this crate
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Debug)]
 pub enum Error<E> {
     /// I²C bus error
@@ -179,7 +179,7 @@ pub enum Error<E> {
 ///
 /// Note that in some devices some of the address bits are used for memory addressing and
 /// will therefore be ignored.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SlaveAddr {
     /// Default slave address
@@ -199,12 +199,12 @@ pub enum SlaveAddr {
 pub mod addr_size {
     /// 1-byte memory address.
     /// e.g. for AT24x00, AT24x01, AT24x02, AT24x04, AT24x08, AT24x16
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct OneByte(());
     /// 2-byte memory address.
     /// e.g. for AT24x32, AT24x64, AT24x128, AT24x256, AT24x512, AT24xM01, AT24xM02
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct TwoBytes(());
 }
@@ -212,31 +212,31 @@ pub mod addr_size {
 /// Page size markers
 pub mod page_size {
     /// No page write supported. e.g. for AT24x00
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct No(());
     /// 8-byte pages. e.g. for AT24x01, AT24x02
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B8(());
     /// 16-byte pages. e.g. for AT24x04, AT24x08, AT24x16
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B16(());
     /// 32-byte pages. e.g. for AT24x32, AT24x64
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B32(());
     /// 64-byte pages. e.g. for AT24x128, AT24x256
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B64(());
     /// 128-byte pages. e.g. for AT24x512
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B128(());
     /// 256-byte pages. e.g. for AT24xM01, AT24xM02
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct B256(());
 }
@@ -244,17 +244,17 @@ pub mod page_size {
 /// Factory-supplied unique serial number markers
 pub mod unique_serial {
     /// Contains a factory-supplied unique serial number. e.g. for AT24CSx
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct Yes(());
     /// No factory-supplied unique serial number
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[derive(Debug)]
     pub struct No(());
 }
 
 /// EEPROM24X driver
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Debug)]
 pub struct Eeprom24x<I2C, PS, AS, SN> {
     /// The concrete I²C device implementation.
@@ -314,7 +314,7 @@ pub trait Eeprom24xTrait: private::Sealed {
 
 /// EEPROM24X extension which supports the `embedded-storage` traits but requires an
 /// `embedded_hal::delay::DelayNs` to handle the timeouts when writing over page boundaries
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Debug)]
 pub struct Storage<I2C, PS, AS, SN, D> {
     /// Eeprom driver over which we implement the Storage traits


### PR DESCRIPTION
Supports defmt::Format operating with the types in this driver. This is especially useful for outputting Errors. To enable operating with defmt, set the feature "defmt" in the dependency.